### PR TITLE
fix: payment network id typing error

### DIFF
--- a/src/controllers/sdk.controller.ts
+++ b/src/controllers/sdk.controller.ts
@@ -7,11 +7,6 @@ import { EthereumPrivateKeySignatureProvider } from "@requestnetwork/epk-signatu
 import * as RequestNetwork from "@requestnetwork/request-client.js";
 import { Order } from "../models/order.model";
 import { Types, Utils } from "@requestnetwork/request-client.js";
-import {
-  IRequestInfo,
-  Payment,
-  RequestLogic,
-} from "@requestnetwork/request-client.js/dist/types";
 
 const decryptPk = async (encrypted_pk: string): Promise<string> => {
   const decrypted = CryptoJS.AES.decrypt(
@@ -43,7 +38,7 @@ export const order = async function (req: Request, res: Response) {
 
     const requestNetwork = requestNetworkFromPK(privateKey);
 
-    const requestInfo: RequestLogic.ICreateParameters | IRequestInfo = {
+    const requestInfo: Types.RequestLogic.ICreateParameters = {
       currency: {
         type: Types.RequestLogic.CURRENCY.ETH,
         value: "ETH",
@@ -54,7 +49,7 @@ export const order = async function (req: Request, res: Response) {
       timestamp: Utils.getCurrentTimestampInSecond(),
     };
 
-    const addressBasedCreateParams = {
+    const addressBasedCreateParams : Types.ICreateRequestParameters = {
       paymentNetwork: {
         id: Types.Extension.PAYMENT_NETWORK_ID.ETH_FEE_PROXY_CONTRACT,
         parameters: {
@@ -71,7 +66,7 @@ export const order = async function (req: Request, res: Response) {
     };
 
     const request = await requestNetwork.createRequest(
-      addressBasedCreateParams
+      addressBasedCreateParams,
     );
 
     const data = request.getData();


### PR DESCRIPTION
# Problem

Code emits the following error during `npm run build`
```
src/controllers/sdk.controller.ts:69:7 - error TS2345: Argument of type '{ paymentNetwork: { id: RequestNetwork.Types.Extension.PAYMENT_NETWORK_ID; parameters: { paymentNetworkName: string; paymentAddress: string; feeAddress: string; feeAmount: string; }; }; requestInfo: RequestNetwork.Types.RequestLogic.ICreateParameters; signer: { ...; }; }' is not assignable to parameter of type 'ICreateRequestParameters'.
  Types of property 'paymentNetwork' are incompatible.
    Type '{ id: RequestNetwork.Types.Extension.PAYMENT_NETWORK_ID; parameters: { paymentNetworkName: string; paymentAddress: string; feeAddress: string; feeAmount: string; }; }' is not assignable to type 'PaymentNetworkCreateParameters | undefined'.
      Type '{ id: RequestNetwork.Types.Extension.PAYMENT_NETWORK_ID; parameters: { paymentNetworkName: string; paymentAddress: string; feeAddress: string; feeAmount: string; }; }' is not assignable to type '{ id: PAYMENT_NETWORK_ID.META; parameters: ICreationParameters; }'.
        Types of property 'id' are incompatible.
          Type 'PAYMENT_NETWORK_ID' is not assignable to type 'PAYMENT_NETWORK_ID.META'.

69       addressBasedCreateParams
         ~~~~~~~~~~~~~~~~~~~~~~~~

Found 1 error in src/controllers/sdk.controller.ts:69
```

# Solution

* Specify types when defining input objects
* Remove unnecessary import